### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ CentOS	Community-supported Linux distribution designed as an OpenSource version 
 Fedora	Community-supported Linux distribution sponsored by Red Hat.
 openSUSE	A community-developed Linux distribution, sponsored by SUSE. It maintains a strict policy of ensuring all code in the standard installs will be from FOSS solutions, including Linux kernel Modules. SUSE's enterprise Linux products are all based on the codebase that comes out of the openSUSE project.
 Mandrake Linux	The first release was based on Red Hat Linux (version 5.1) and KDE 1 in July 1998. It had since moved away from Red Hat's distribution and became a completely separate distribution. The name was changed to Mandriva, which included a number of original tools, mostly to ease system configuration. Mandriva Linux was the brainchild of Gaël Duval, who wanted to focus on ease of use for new users.
+
+Distribution	Description
+Red Hat Linux	Split into Fedora Core and Red Hat Enterprise Linux. The last official release of the unsplit distribution was Red Hat Linux 9 in March 2003.
+CentOS	Community-supported Linux distribution designed as an OpenSource version of RHEL and well suited for servers. Now sponsored by Red Hat.[2]
+Fedora	Community-supported Linux distribution sponsored by Red Hat.
+openSUSE	A community-developed Linux distribution, sponsored by SUSE. It maintains a strict policy of ensuring all code in the standard installs will be from FOSS solutions, including Linux kernel Modules. SUSE's enterprise Linux products are all based on the codebase that comes out of the openSUSE project.
+Mandrake Linux	The first release was based on Red Hat Linux (version 5.1) and KDE 1 in July 1998. It had since moved away from Red Hat's distribution and became a completely separate distribution. The name was changed to Mandriva, which included a number of original tools, mostly to ease system configuration. Mandriva Linux was the brainchild of Gaël Duval, who wanted to focus on ease of use for new users.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Distribution | Description
-- | --
Red Hat Linux | Split into Fedora Core and Red Hat Enterprise Linux. The last official release of the unsplit distribution was Red Hat Linux 9 in March 2003.
CentOS | Community-supported Linux distribution designed as an OpenSource version of RHEL and well suited for servers. Now sponsored by Red Hat.[2]
Fedora | Community-supported Linux distribution sponsored by Red Hat.
openSUSE | A community-developed Linux distribution, sponsored by SUSE. It maintains a strict policy of ensuring all code in the standard installs will be from FOSS solutions, including Linux kernel Modules. SUSE's enterprise Linux products are all based on the codebase that comes out of the openSUSE project.
Mandrake Linux | The first release was based on Red Hat Linux (version 5.1) and KDE 1 in July 1998. It had since moved away from Red Hat's distribution and became a completely separate distribution. The name was changed to Mandriva, which included a number of original tools, mostly to ease system configuration. Mandriva Linux was the brainchild of Gaël Duval, who wanted to focus on ease of use for new users.

<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>